### PR TITLE
Add sync triggers debounce

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/Shopify/sarama v1.36.0
+	github.com/bep/debounce v1.2.1
 	github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
 	github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bep/debounce v1.2.1 h1:v67fRdBA9UQu2NhLFXrSg0Brw7CexQekrBwDMM8bzeY=
+github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3ISbCJ0=
 github.com/blend/go-sdk v1.20220112.5 h1:M1H3KB++HyPAek31WH2HNut1Xg1SI7LyT9giNE2fcPQ=
 github.com/blend/go-sdk v1.20220112.5/go.mod h1:STLiO8ZA8doHtRV7QfW2mXgH/8U+85GHY9ge3phM3dY=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=


### PR DESCRIPTION
We run a Fission deployment with about 12k functions and 12k triggers.

When the K8S Informers for `HTTPTrigger` and `Function` are instantiated their state synchronized by calling the `AddFunc` event handler for each function and trigger. In our deployment, this means 24k calls to `syncTriggers`.

Every time `syncTriggers` is called the router's `Mux` is rebuilt from scratch as part of `getRouter`.

In our deployment, this causes our routers to max out their CPU for a couple hours after they are rebooted. The routers are still able to serve traffic while this is happening, but they time out many more requests than they should.
