### PR TITLE
Disable otelhttp

### DIFF
--- a/pkg/router/httpTriggers.go
+++ b/pkg/router/httpTriggers.go
@@ -37,7 +37,6 @@ import (
 	"github.com/fission/fission/pkg/throttler"
 	"github.com/fission/fission/pkg/utils"
 	"github.com/fission/fission/pkg/utils/metrics"
-	"github.com/fission/fission/pkg/utils/otel"
 )
 
 // HTTPTriggerSet represents an HTTP trigger set
@@ -186,12 +185,14 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) *mux.Router 
 			}
 		}
 
-		var handler http.Handler
-		if trigger.Spec.Prefix != nil && *trigger.Spec.Prefix != "" {
-			handler = otel.GetHandlerWithOTEL(http.HandlerFunc(fh.handler), *trigger.Spec.Prefix)
-		} else {
-			handler = otel.GetHandlerWithOTEL(http.HandlerFunc(fh.handler), trigger.Spec.RelativeURL)
-		}
+		// FIXME: Re-add otelhttp
+		// var handler http.Handler
+		// if trigger.Spec.Prefix != nil && *trigger.Spec.Prefix != "" {
+		// 	handler = otel.GetHandlerWithOTEL(http.HandlerFunc(fh.handler), *trigger.Spec.Prefix)
+		// } else {
+		// 	handler = otel.GetHandlerWithOTEL(http.HandlerFunc(fh.handler), trigger.Spec.RelativeURL)
+		// }
+		handler := http.HandlerFunc(fh.handler)
 
 		if trigger.Spec.Prefix != nil && *trigger.Spec.Prefix != "" {
 			prefix := *trigger.Spec.Prefix
@@ -258,7 +259,10 @@ func (ts *HTTPTriggerSet) getRouter(fnTimeoutMap map[types.UID]int) *mux.Router 
 		var handler http.Handler
 		internalRoute := utils.UrlForFunction(fn.ObjectMeta.Name, fn.ObjectMeta.Namespace)
 		internalPrefixRoute := internalRoute + "/"
-		handler = otel.GetHandlerWithOTEL(http.HandlerFunc(fh.handler), internalRoute)
+
+		// FIXME: Re-add otelhttp
+		// handler = otel.GetHandlerWithOTEL(http.HandlerFunc(fh.handler), internalRoute)
+		handler = http.HandlerFunc(fh.handler)
 
 		muxRouter.Handle(internalRoute, handler)
 		muxRouter.PathPrefix(internalPrefixRoute).Handler(handler)


### PR DESCRIPTION
This will disable `otelhttp` for the router.

I don't think this will solve the memory leak just slow it down a whole lot.

```
/ # ./pprof -top -cum http://localhost:6060/debug/pprof/heap
Fetching profile over HTTP from http://localhost:6060/debug/pprof/heap
Saved profile in /root/pprof/pprof.fission-bundle.alloc_objects.alloc_space.inuse_objects.inuse_space.009.pb.gz
File: fission-bundle
Type: inuse_space
Time: Dec 7, 2022 at 6:22pm (UTC)
Showing nodes accounting for 2107.09MB, 95.40% of 2208.62MB total
Dropped 220 nodes (cum <= 11.04MB)
      flat  flat%   sum%        cum   cum%
   21.27MB  0.96%  0.96%  2118.70MB 95.93%  github.com/fission/fission/pkg/router.(*HTTPTriggerSet).updateRouter
   45.02MB  2.04%  3.00%  2097.43MB 94.97%  github.com/fission/fission/pkg/router.(*HTTPTriggerSet).getRouter
         0     0%  3.00%  1506.74MB 68.22%  github.com/fission/fission/pkg/utils/otel.GetHandlerWithOTEL
   10.50MB  0.48%  3.48%  1506.74MB 68.22%  go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewHandler
   34.01MB  1.54%  5.02%  1495.24MB 67.70%  go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*Handler).createMeasures
  867.45MB 39.28% 44.29%   867.45MB 39.28%  go.opentelemetry.io/otel/metric/internal/global.(*siInstProvider).Counter
  593.78MB 26.88% 71.18%   593.78MB 26.88%  go.opentelemetry.io/otel/metric/internal/global.(*sfInstProvider).Histogram
         0     0% 71.18%   515.66MB 23.35%  github.com/gorilla/mux.(*Route).addRegexpMatcher
      12MB  0.54% 71.72%   512.16MB 23.19%  github.com/gorilla/mux.newRouteRegexp
         0     0% 71.72%   489.69MB 22.17%  regexp.Compile (inline)
      20MB  0.91% 72.63%   489.69MB 22.17%  regexp.compile
         0     0% 72.63%   320.60MB 14.52%  github.com/gorilla/mux.(*Router).Handle
         0     0% 72.63%   314.10MB 14.22%  github.com/gorilla/mux.(*Route).Path (inline)
         0     0% 72.63%   295.13MB 13.36%  regexp/syntax.Compile
  288.63MB 13.07% 85.69%   288.63MB 13.07%  regexp/syntax.(*compiler).inst (inline)
         0     0% 85.69%   288.13MB 13.05%  regexp/syntax.(*compiler).compile
         0     0% 85.69%   287.60MB 13.02%  regexp/syntax.(*compiler).rune
         0     0% 85.69%   214.56MB  9.71%  github.com/gorilla/mux.(*Router).PathPrefix
         0     0% 85.69%   201.56MB  9.13%  github.com/gorilla/mux.(*Route).PathPrefix (inline)
         0     0% 85.69%   145.55MB  6.59%  regexp.compileOnePass
  138.04MB  6.25% 91.94%   138.04MB  6.25%  regexp.onePassCopy
         0     0% 91.94%    56.87MB  2.58%  k8s.io/apimachinery/pkg/runtime.WithoutVersionDecoder.Decode
         0     0% 91.94%    56.87MB  2.58%  k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).Decode
         0     0% 91.94%    56.37MB  2.55%  k8s.io/apimachinery/pkg/runtime/serializer/json.(*Serializer).unmarshal
         0     0% 91.94%    56.37MB  2.55%  sigs.k8s.io/json.UnmarshalCaseSensitivePreserveInts (inline)
    0.50MB 0.023% 91.97%    56.37MB  2.55%  sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).object
         0     0% 91.97%    56.37MB  2.55%  sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).unmarshal
         0     0% 91.97%    56.37MB  2.55%  sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).value
         0     0% 91.97%    56.37MB  2.55%  sigs.k8s.io/json/internal/golang/encoding/json.Unmarshal
         0     0% 91.97%    55.87MB  2.53%  k8s.io/client-go/rest.Result.Into
         0     0% 91.97%    55.87MB  2.53%  k8s.io/client-go/tools/cache.(*ListWatch).List
         0     0% 91.97%    55.87MB  2.53%  k8s.io/client-go/tools/cache.(*Reflector).list.func1
         0     0% 91.97%    55.87MB  2.53%  k8s.io/client-go/tools/cache.(*Reflector).list.func1.2
         0     0% 91.97%    55.87MB  2.53%  k8s.io/client-go/tools/pager.(*ListPager).List
         0     0% 91.97%    55.87MB  2.53%  k8s.io/client-go/tools/pager.SimplePageFunc.func1
         0     0% 91.97%    55.87MB  2.53%  sigs.k8s.io/json/internal/golang/encoding/json.(*decodeState).array
         0     0% 91.97%    32.59MB  1.48%  github.com/fission/fission/pkg/generated/clientset/versioned/typed/core/v1.(*functions).List
         0     0% 91.97%    32.59MB  1.48%  github.com/fission/fission/pkg/generated/informers/externalversions/core/v1.NewFilteredFunctionInformer.func1
         0     0% 91.97%    24.01MB  1.09%  regexp/syntax.Parse (inline)
    0.50MB 0.023% 91.99%    24.01MB  1.09%  regexp/syntax.parse
         0     0% 91.99%    23.29MB  1.05%  github.com/fission/fission/pkg/generated/clientset/versioned/typed/core/v1.(*hTTPTriggers).List
         0     0% 91.99%    23.29MB  1.05%  github.com/fission/fission/pkg/generated/informers/externalversions/core/v1.NewFilteredHTTPTriggerInformer.func1
         0     0% 91.99%    23.01MB  1.04%  regexp/syntax.(*parser).literal
   22.01MB     1% 92.99%    22.01MB     1%  regexp/syntax.(*parser).maybeConcat
         0     0% 92.99%    22.01MB     1%  regexp/syntax.(*parser).push
         0     0% 92.99%    20.36MB  0.92%  reflect.MakeSlice
   20.36MB  0.92% 93.91%    20.36MB  0.92%  reflect.unsafe_NewArray
   19.50MB  0.88% 94.79%    19.50MB  0.88%  github.com/gorilla/mux.(*Router).NewRoute (inline)
```

I suspect the issue is that the router cannot GC old Gorilla Muxes that it creates, but I'd like to start here.

Similar issue seen here: https://github.com/open-telemetry/opentelemetry-go-contrib/issues/2413

But in our case we actually do have a bunch of new handlers and need to wrap them all for OTEL.
