### PR TITLE
Increase K8S client QPS

### DIFF
--- a/pkg/crd/client.go
+++ b/pkg/crd/client.go
@@ -56,6 +56,9 @@ func GetKubernetesClient() (*rest.Config, kubernetes.Interface, apiextensionscli
 		}
 	}
 
+	config.QPS = 20
+	config.Burst = 50
+
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
Let the Fission K8S clients use more of our API server's resources.

During a deploy we seem to have been hitting the default limits which are:

```
QPS: 5
Burst: 10
```