### PR TITLE
Fetcher Security

### DIFF
--- a/pkg/fetcher/config/config.go
+++ b/pkg/fetcher/config/config.go
@@ -309,7 +309,18 @@ func (cfg *Config) addFetcherToPodSpecWithCommand(podSpec *apiv1.PodSpec, mainCo
 		}
 
 		found = true
-		container.VolumeMounts = append(container.VolumeMounts, mounts...)
+
+		// use a readonly version of the mounts so that the fetcher is the only container with write access to the shared volumes
+		readOnlyMounts := make([]apiv1.VolumeMount, len(mounts))
+		for ix, mount := range mounts {
+			readOnlyMounts[ix] = apiv1.VolumeMount{
+				Name:      mount.Name,
+				MountPath: mount.MountPath,
+				ReadOnly:  true,
+			}
+		}
+
+		container.VolumeMounts = append(container.VolumeMounts, readOnlyMounts...)
 		podSpec.Containers[ix] = container
 	}
 	if !found {

--- a/pkg/fetcher/fetcher.go
+++ b/pkg/fetcher/fetcher.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/mholt/archiver/v3"
@@ -63,6 +64,7 @@ type (
 		fissionClient    versioned.Interface
 		kubeClient       kubernetes.Interface
 		httpClient       *http.Client
+		isSpecialized    *atomic.Bool
 		Info             PodInfo
 	}
 	PodInfo struct {
@@ -105,6 +107,40 @@ func MakeFetcher(logger *zap.Logger, sharedVolumePath string, sharedSecretPath s
 		return nil, errors.Wrap(err, "error reading pod namespace from downward volume")
 	}
 
+	hasFiles := func(dir string) (bool, error) {
+		f, err := os.Open(dir)
+		if err != nil {
+			return false, err
+		}
+		defer f.Close()
+
+		_, err = f.Readdirnames(1)
+		if err == io.EOF {
+			return false, nil
+		}
+		return true, err
+	}
+
+	userFuncHasFiles, err := hasFiles(sharedVolumePath)
+	if err != nil {
+		return nil, err
+	}
+
+	secretsHasFiles, err := hasFiles(sharedSecretPath)
+	if err != nil {
+		return nil, err
+	}
+
+	configMapsHasFiles, err := hasFiles(sharedConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	// if any of the directories have files, then the pod has already been specialized.
+	// we made these volumes read only for the sandbox here: pkg/fetcher/config/config.go:323
+	isSpecialized := &atomic.Bool{}
+	isSpecialized.Store(userFuncHasFiles || secretsHasFiles || configMapsHasFiles)
+
 	hc := &http.Client{Transport: otelhttp.NewTransport(http.DefaultTransport)}
 	return &Fetcher{
 		logger:           fLogger,
@@ -113,6 +149,7 @@ func MakeFetcher(logger *zap.Logger, sharedVolumePath string, sharedSecretPath s
 		sharedConfigPath: sharedConfigPath,
 		fissionClient:    fissionClient,
 		kubeClient:       kubeClient,
+		isSpecialized:    isSpecialized,
 		Info: PodInfo{
 			Name:      string(name),
 			Namespace: string(namespace),
@@ -166,6 +203,12 @@ func (fetcher *Fetcher) FetchHandler(w http.ResponseWriter, r *http.Request) {
 		logger.Info("fetch request done", zap.Duration("elapsed_time", elapsed))
 	}()
 
+	if fetcher.isSpecialized.Load() {
+		logger.Warn("fetch request received on specialized pod")
+		w.WriteHeader(http.StatusTeapot)
+		return
+	}
+
 	// parse request
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -216,6 +259,12 @@ func (fetcher *Fetcher) SpecializeHandler(w http.ResponseWriter, r *http.Request
 		return
 	}
 	logger := otelUtils.LoggerWithTraceID(ctx, fetcher.logger)
+
+	if fetcher.isSpecialized.Load() {
+		logger.Warn("specialize request received on specialized pod")
+		w.WriteHeader(http.StatusTeapot)
+		return
+	}
 
 	// parse request
 	body, err := io.ReadAll(r.Body)
@@ -507,6 +556,12 @@ func (fetcher *Fetcher) UploadHandler(w http.ResponseWriter, r *http.Request) {
 		logger.Info("upload request done", zap.Duration("elapsed_time", elapsed))
 	}()
 
+	if fetcher.isSpecialized.Load() {
+		logger.Warn("upload request received on specialized pod")
+		w.WriteHeader(http.StatusTeapot)
+		return
+	}
+
 	// parse request
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -725,6 +780,7 @@ func (fetcher *Fetcher) SpecializePod(ctx context.Context, fetchReq FunctionFetc
 		if err == nil && resp.StatusCode < 300 {
 			// Success
 			resp.Body.Close()
+			fetcher.isSpecialized.Store(true)
 			return nil
 		}
 


### PR DESCRIPTION
The fission fetcher listens on `localhost:8000` within our sandbox pods and has the `/specialize` and `/fetch` endpoints. Both of these endpoints accept a `POST` request that makes the fetcher fetch an archive, list of secrets, and a list of config maps to store in shared volume mounts.

These endpoints are necessary to specialize a pod, but once the pod has been specialized these endpoints open a security vulnerability where a sandbox can make a request to `localhost:8000` and make the fetcher store another apps archive, secrets, etc...

---

This PR does 2 things to address the above:

1. Changes the fetcher to keep track of whether it has specialized the pod and noops any subsequent requests to `/specialize`, `/fetch`, and `/upload` if it has.
2. Changes the shared volume mounts to be readonly for the non-fetcher container (in our case, the sandbox).

We track whether the fetcher has specialized the pod by using an in memory `atomic.Bool`. This boolean is set to `true` after we successfully specialize **or** if the shared volumes aren't empty when the fetcher starts up. Setting `isSpecialized` to `true` on start up if the shared volumes aren't empty prevents the sandbox from restarting the fetcher and having the boolean reset. Since we changed the mounted volumes to readonly, the sandbox cannot delete the files and make the fetcher think it hasn't specialized.