### PR TITLE
Increase K8S client QPS v2

### DIFF
--- a/pkg/crd/client.go
+++ b/pkg/crd/client.go
@@ -56,8 +56,8 @@ func GetKubernetesClient() (*rest.Config, kubernetes.Interface, apiextensionscli
 		}
 	}
 
-	config.QPS = 20
-	config.Burst = 50
+	config.QPS = 200
+	config.Burst = 500
 
 	// creates the clientset
 	clientset, err := kubernetes.NewForConfig(config)


### PR DESCRIPTION
We increased the K8S client's QPS and Burst in #4 but still ran into timeouts. It looks like other projects have set their QPS and Bursts to much higher values without issues so let's bump fissions even more.

References:
- https://github.com/voyagermesh/voyager/issues/640#issuecomment-337450743
- https://github.com/Kong/kubernetes-ingress-controller/pull/2169/files#diff-f45c581008bda413c341fdf775a5220e0193e4d268db67eae49f6eabba06d729R122-R123
- https://github.com/rancher/support-bundle-kit/pull/23/files#diff-92be285ab4b27274a0724d7f89a21cd1aed1a40d670c4e3afad3475a640cf0f5R18-R21