### PR TITLE
Fix telemetry shutdown

### DIFF
--- a/cmd/fetcher/app/server.go
+++ b/cmd/fetcher/app/server.go
@@ -65,7 +65,7 @@ func Run(ctx context.Context, logger *zap.Logger) {
 		logger.Fatal("error initializing provider for OTLP", zap.Error(err))
 	}
 	if shutdown != nil {
-		defer shutdown(ctx)
+		defer shutdown()
 	}
 
 	tracer := otel.Tracer("fetcher")

--- a/cmd/fission-bundle/main.go
+++ b/cmd/fission-bundle/main.go
@@ -215,7 +215,7 @@ Options:
 		return
 	}
 	if shutdown != nil {
-		defer shutdown(ctx)
+		defer shutdown()
 	}
 
 	functionNs := getStringArgWithDefault(arguments["--namespace"], "fission-function")

--- a/pkg/fission-cli/cmd/function/test.go
+++ b/pkg/fission-cli/cmd/function/test.go
@@ -163,7 +163,7 @@ func doHTTPRequest(ctx context.Context, url string, headers []string, method, bo
 		return nil, err
 	}
 	if shutdown != nil {
-		defer shutdown(ctx)
+		defer shutdown()
 	}
 
 	tracer := otel.Tracer("fission-cli")


### PR DESCRIPTION
We're seeing a ton of these logs in Humio:

```json
{
	"applicationId":"21279",
	"caller":"otel/provider.go:101",
	"environmentId":"41239",
	"error":"context canceled",
	"level":"error",
	"msg":"error shutting down trace provider",
	"stacktrace":"github.com/fission/fission/pkg/utils/otel.InitProvider.func1\n\tpkg/utils/otel/provider.go:101\ngithub.com/fission/fission/cmd/fetcher/app.Run\n\tcmd/fetcher/app/server.go:123\nmain.main\n\tcmd/fetcher/main.go:33\nruntime.main\n\t/opt/homebrew/Cellar/go/1.19.5/libexec/src/runtime/proc.go:250",
	"ts":"2023-02-28T16:00:41.414Z"
}
```

These errors are happening because the `ctx` that's passed to `shutdown` comes from [`SetupSignalHandlerWithContext `](https://github.com/gadget-inc/fission/blob/sc/fix-telemetry-shutdown/pkg/utils/signals/signals.go#L29-L46) which is already cancelled by the time `shutdown` runs.

This changes `shutdown` use its own `ctx` with a 30 second timeout.