### PR TITLE
Check context after acquiring key

### DIFF
--- a/pkg/executor/executortype/poolmgr/gp.go
+++ b/pkg/executor/executortype/poolmgr/gp.go
@@ -96,8 +96,8 @@ func MakeGenericPool(
 	fetcherConfig *fetcherConfig.Config,
 	instanceID string,
 	enableIstio bool,
-	podSpecPatch *apiv1.PodSpec) *GenericPool {
-
+	podSpecPatch *apiv1.PodSpec,
+) *GenericPool {
 	gpLogger := logger.Named("generic_pool")
 
 	podReadyTimeoutStr := os.Getenv("POD_READY_TIMEOUT")
@@ -250,6 +250,23 @@ func (gp *GenericPool) choosePod(ctx context.Context, newLabels map[string]strin
 			return "", nil, errors.New("readypod controller is not running")
 		}
 		key = item.(string)
+
+		select {
+		case <-ctx.Done():
+			gp.readyPodQueue.Done(key)
+			gp.readyPodQueue.Add(key)
+			logger.Error("context cancelled before getting key", zap.String("key", key))
+			return "", nil, errors.New("context cancelled before getting key")
+		default:
+			deadline, ok := ctx.Deadline()
+			if ok && time.Until(deadline) < 3*time.Second {
+				gp.readyPodQueue.Done(key)
+				gp.readyPodQueue.Add(key)
+				logger.Error("context is to close to deadline after getting key", zap.String("key", key), zap.Stringer("deadline", time.Until(deadline)))
+				return "", nil, fmt.Errorf("context is %s from deadline after getting key", time.Until(deadline))
+			}
+		}
+
 		logger.Debug("got key from the queue", zap.String("key", key))
 		namespace, name, err := cache.SplitMetaNamespaceKey(key)
 		if err != nil {
@@ -421,7 +438,6 @@ func (gp *GenericPool) specializePod(ctx context.Context, pod *apiv1.Pod, fn *fv
 			} else {
 				return err
 			}
-
 		}
 	}
 	// specialize pod with service


### PR DESCRIPTION
This checks our `ctx` after acquiring a key from `readyPodQueue`. If the context is cancelled or about to be cancelled we add the key back and give up.

I arbitrarily chose 1 second as our "to close to being cancelled" limit but I'm open to change that.