### PR TITLE
Only pre-stop if specialized

### DIFF
--- a/pkg/executor/executortype/container/deployment.go
+++ b/pkg/executor/executortype/container/deployment.go
@@ -226,12 +226,14 @@ func (cn *Container) getDeploymentSpec(ctx context.Context, fn *fv1.Function, ta
 		Name:                   fn.ObjectMeta.Name,
 		ImagePullPolicy:        cn.runtimeImagePullPolicy,
 		TerminationMessagePath: "/dev/termination-log",
+		// if the pod is specialized (i.e. has secrets), wait 60 seconds for the routers endpoint cache to expire before shutting down
 		Lifecycle: &apiv1.Lifecycle{
 			PreStop: &apiv1.LifecycleHandler{
 				Exec: &apiv1.ExecAction{
 					Command: []string{
-						"/bin/sleep",
-						fmt.Sprintf("%v", gracePeriodSeconds),
+						"bash",
+						"-c",
+						"test $(ls /secrets/) && sleep 63 || exit 0",
 					},
 				},
 			},

--- a/pkg/executor/executortype/newdeploy/newdeploy.go
+++ b/pkg/executor/executortype/newdeploy/newdeploy.go
@@ -190,12 +190,14 @@ func (deploy *NewDeploy) getDeploymentSpec(ctx context.Context, fn *fv1.Function
 		Image:                  env.Spec.Runtime.Image,
 		ImagePullPolicy:        deploy.runtimeImagePullPolicy,
 		TerminationMessagePath: "/dev/termination-log",
+		// if the pod is specialized (i.e. has secrets), wait 60 seconds for the routers endpoint cache to expire before shutting down
 		Lifecycle: &apiv1.Lifecycle{
 			PreStop: &apiv1.LifecycleHandler{
 				Exec: &apiv1.ExecAction{
 					Command: []string{
-						"/bin/sleep",
-						fmt.Sprintf("%v", gracePeriodSeconds),
+						"bash",
+						"-c",
+						"test $(ls /secrets/) && sleep 63 || exit 0",
 					},
 				},
 			},

--- a/pkg/executor/executortype/poolmgr/gp_deployment.go
+++ b/pkg/executor/executortype/poolmgr/gp_deployment.go
@@ -103,18 +103,14 @@ func (gp *GenericPool) genDeploymentSpec(env *fv1.Environment) (*appsv1.Deployme
 		ImagePullPolicy:        gp.runtimeImagePullPolicy,
 		TerminationMessagePath: "/dev/termination-log",
 		Resources:              env.Spec.Resources,
-		// Pod is removed from endpoints list for service when it's
-		// state became "Termination". We used preStop hook as the
-		// workaround for connection draining since pod maybe shutdown
-		// before grace period expires.
-		// https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
-		// https://github.com/kubernetes/kubernetes/issues/47576#issuecomment-308900172
+		// if the pod is specialized (i.e. has secrets), wait 60 seconds for the routers endpoint cache to expire before shutting down
 		Lifecycle: &apiv1.Lifecycle{
 			PreStop: &apiv1.LifecycleHandler{
 				Exec: &apiv1.ExecAction{
 					Command: []string{
-						"/bin/sleep",
-						fmt.Sprintf("%v", gracePeriodSeconds),
+						"bash",
+						"-c",
+						"test $(ls /secrets/) && sleep 63 || exit 0",
 					},
 				},
 			},

--- a/pkg/fetcher/config/config.go
+++ b/pkg/fetcher/config/config.go
@@ -2,7 +2,6 @@ package container
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -269,25 +268,6 @@ func (cfg *Config) addFetcherToPodSpecWithCommand(podSpec *apiv1.PodSpec, mainCo
 			},
 		},
 		Env: otel.OtelEnvForContainer(),
-	}
-
-	// Pod is removed from endpoints list for service when it's
-	// state became "Termination". We used preStop hook as the
-	// workaround for connection draining since pod maybe shutdown
-	// before grace period expires.
-	// https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
-	// https://github.com/kubernetes/kubernetes/issues/47576#issuecomment-308900172
-	if podSpec.TerminationGracePeriodSeconds != nil {
-		c.Lifecycle = &apiv1.Lifecycle{
-			PreStop: &apiv1.LifecycleHandler{
-				Exec: &apiv1.ExecAction{
-					Command: []string{
-						"/bin/sleep",
-						fmt.Sprintf("%v", *podSpec.TerminationGracePeriodSeconds),
-					},
-				},
-			},
-		}
 	}
 
 	found := false


### PR DESCRIPTION
This makes our pre-stop hook only sleep if the pod is specialized. This will make unspecialized pods release their resources much faster. I also lowered the sleep amount from 120 seconds (`gracePeriodSeconds`) to 60 seconds since that's how long a router caches a specialized pod's IP.

To determine if a pod is specialized, I check if the `/secrets/` directory is empty. We can't just check if the directory exists because it always exists (it's mounted as an empty dir).