### PR TITLE
Ensure funcSvcGroup is not nil

### DIFF
--- a/pkg/executor/fscache/poolcache.go
+++ b/pkg/executor/fscache/poolcache.go
@@ -157,7 +157,7 @@ func (c *PoolCache) service() {
 			}
 
 			// concurrency should not be set to zero and
-			//sum of specialization in progress and specialized pods should be less then req.concurrency
+			// sum of specialization in progress and specialized pods should be less then req.concurrency
 			if req.concurrency > 0 && (specializationInProgress+len(funcSvcGroup.svcs)) >= req.concurrency {
 				resp.error = ferror.MakeError(ferror.ErrorTooManyRequests, fmt.Sprintf("function '%s' concurrency '%d' limit reached.", req.function, req.concurrency))
 			} else {
@@ -238,11 +238,16 @@ func (c *PoolCache) service() {
 				}
 			}
 		case markSpecializationFailure:
-			if c.cache[req.function].svcWaiting > c.cache[req.function].queue.Len() {
-				c.cache[req.function].svcWaiting--
-				if c.cache[req.function].svcWaiting == c.cache[req.function].queue.Len() {
-					expiredRequests := c.cache[req.function].queue.Expired()
-					c.cache[req.function].svcWaiting = c.cache[req.function].svcWaiting - expiredRequests
+			funcSvcGroup, ok := c.cache[req.function]
+			if !ok || funcSvcGroup == nil {
+				break
+			}
+
+			if funcSvcGroup.svcWaiting > funcSvcGroup.queue.Len() {
+				funcSvcGroup.svcWaiting--
+				if funcSvcGroup.svcWaiting == funcSvcGroup.queue.Len() {
+					expiredRequests := funcSvcGroup.queue.Expired()
+					funcSvcGroup.svcWaiting = funcSvcGroup.svcWaiting - expiredRequests
 				}
 			}
 		case deleteValue:


### PR DESCRIPTION
Attempt to fix this error in production

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1d2174f]

goroutine 138 [running]:
github.com/fission/fission/pkg/executor/fscache.(*PoolCache).service(0xc000e8c1e0)
	pkg/executor/fscache/poolcache.go:241 +0x11ef
created by github.com/fission/fission/pkg/executor/fscache.NewPoolCache
	pkg/executor/fscache/poolcache.go:99 +0xe5
```