### PR TITLE
Always use a new ctx when shutting down otel

### DIFF
--- a/pkg/utils/otel/provider.go
+++ b/pkg/utils/otel/provider.go
@@ -96,13 +96,11 @@ func InitProvider(ctx context.Context, logger *zap.Logger, serviceName string) (
 	otel.SetTracerProvider(tracerProvider)
 	otel.SetTextMapPropagator(autoprop.NewTextMapPropagator())
 	// Shutdown will flush any remaining spans and shut down the exporter.
-	return func(ctx context.Context) {
-		if ctx.Err() != nil {
-			// if the context is already cancelled, create a new one with a timeout of 30 seconds
-			ctxwithTimeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-			ctx = ctxwithTimeout
-		}
+	return func(_ context.Context) {
+		// create a new context with a timeout of 30 seconds
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
 		err := tracerProvider.Shutdown(ctx)
 		if err != nil && logger != nil {
 			logger.Error("error shutting down trace provider", zap.Error(err))


### PR DESCRIPTION
This makes the OTEL shutdown function always use a new context with a 30 second timeout, rather than using a new context if the passed in one is already cancelled. This avoids using a context that is about to expire (instead of having already expired).